### PR TITLE
Fix and Enhance the File Change Tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: cargo build
 
       - name: Cargo Test
-        run: cargo test --all-features -- -Z unstable-options --format json --report-time | cargo2junit > target/debug/results.xml
+        run: cargo test --all-features -- --test-threads=1 -Z unstable-options --format json --report-time | cargo2junit > target/debug/results.xml
 
       # REF: https://github.com/marketplace/actions/publish-test-results
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "more-changetoken"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2018"
-authors = ["Chris Martinez <chris.s.martinez@hotmail.com>"]
+authors = ["Chris Martinez <chris.s.martinez@outlook.com>"]
 description = "Provides support for change tokens"
 keywords = ["more", "change", "token"]
 license = "MIT"
@@ -26,7 +26,6 @@ fs = ["notify"]
 [dependencies]
 notify = { version = "6.1", optional = true }
 
-[dev-dependencies.more-changetoken]
-path = "."
-default-features = false
-features = ["fs"]
+[dev-dependencies]
+more-changetoken = { path = ".", features = ["fs"] }
+tempfile = "3.22"

--- a/src/composite.rs
+++ b/src/composite.rs
@@ -98,7 +98,7 @@ mod tests {
     use crate::*;
     use std::iter::empty;
     use std::sync::{
-        atomic::{AtomicU8, Ordering},
+        atomic::{AtomicU8, Ordering::Relaxed},
         Arc,
     };
 
@@ -191,7 +191,7 @@ mod tests {
                     .unwrap()
                     .downcast_ref::<AtomicU8>()
                     .unwrap()
-                    .fetch_add(1, Ordering::SeqCst);
+                    .fetch_add(1, Relaxed);
             }),
             Some(counter.clone()),
         );
@@ -200,7 +200,7 @@ mod tests {
         child.notify();
 
         // assert
-        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.load(Relaxed), 1);
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod tests {
                     .unwrap()
                     .downcast_ref::<AtomicU8>()
                     .unwrap()
-                    .fetch_add(1, Ordering::SeqCst);
+                    .fetch_add(1, Relaxed);
             }),
             Some(counter.clone()),
         );
@@ -227,7 +227,7 @@ mod tests {
         child.notify();
 
         // assert
-        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.load(Relaxed), 1);
     }
 
     #[test]
@@ -243,7 +243,7 @@ mod tests {
                     .unwrap()
                     .downcast_ref::<AtomicU8>()
                     .unwrap()
-                    .fetch_add(1, Ordering::SeqCst);
+                    .fetch_add(1, Relaxed);
             }),
             Some(counter.clone()),
         );
@@ -254,6 +254,6 @@ mod tests {
         token.notify();
 
         // assert
-        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.load(Relaxed), 1);
     }
 }

--- a/src/default.rs
+++ b/src/default.rs
@@ -7,17 +7,15 @@ use std::{
     },
 };
 
+type StatefulCallback = dyn Fn(Option<Arc<dyn Any>>) + Send + Sync;
+type CallbackWithState = (Weak<StatefulCallback>, Option<Arc<dyn Any>>);
+
 /// Represents a default [`ChangeToken`](crate::ChangeToken) that may change zero or more times.
 #[derive(Default)]
 pub struct DefaultChangeToken {
     once: bool,
     changed: AtomicBool,
-    callbacks: RwLock<
-        Vec<(
-            Weak<dyn Fn(Option<Arc<dyn Any>>) + Send + Sync>,
-            Option<Arc<dyn Any>>,
-        )>,
-    >,
+    callbacks: RwLock<Vec<CallbackWithState>>,
 }
 
 impl DefaultChangeToken {
@@ -87,7 +85,7 @@ impl ChangeToken for DefaultChangeToken {
             }
         }
 
-        let source: Arc<dyn Fn(Option<Arc<dyn Any>>) + Send + Sync> = Arc::from(callback);
+        let source: Arc<StatefulCallback> = Arc::from(callback);
 
         callbacks.push((Arc::downgrade(&source), state));
         Registration::new(source)

--- a/src/default.rs
+++ b/src/default.rs
@@ -1,21 +1,72 @@
 use crate::{Callback, ChangeToken, Registration};
 use std::{
     any::Any,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, RwLock, Weak,
-    },
+    mem,
+    sync::{Arc, Mutex, Weak},
 };
 
-type StatefulCallback = dyn Fn(Option<Arc<dyn Any>>) + Send + Sync;
-type CallbackWithState = (Weak<StatefulCallback>, Option<Arc<dyn Any>>);
+type State = Option<Arc<dyn Any>>;
+type StatefulCallback = dyn Fn(State) + Send + Sync;
+type CallbackWithState = (Weak<StatefulCallback>, State);
+
+struct Ready {
+    fired: bool,
+    callbacks: Vec<(Arc<StatefulCallback>, State)>,
+}
+
+impl IntoIterator for Ready {
+    type Item = (Arc<StatefulCallback>, State);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.callbacks.into_iter()
+    }
+}
+
+#[derive(Default)]
+struct Notification {
+    fired: bool,
+    callbacks: Vec<CallbackWithState>,
+}
+
+impl Notification {
+    fn fire(&mut self, once: bool) -> Ready {
+        Ready {
+            fired: mem::replace(&mut self.fired, once),
+            callbacks: self
+                .callbacks
+                .iter()
+                .filter_map(|r| r.0.upgrade().map(|c| (c, r.1.clone())))
+                .collect(),
+        }
+    }
+
+    fn register(
+        &mut self,
+        callback: Callback,
+        state: Option<Arc<dyn Any>>,
+    ) -> Arc<StatefulCallback> {
+        // writes are much infrequent, so do the trimming of any dead callbacks now
+        if !self.callbacks.is_empty() {
+            for i in (0..self.callbacks.len()).rev() {
+                if self.callbacks[i].0.upgrade().is_none() {
+                    self.callbacks.remove(i);
+                }
+            }
+        }
+
+        let source: Arc<StatefulCallback> = Arc::from(callback);
+
+        self.callbacks.push((Arc::downgrade(&source), state));
+        source
+    }
+}
 
 /// Represents a default [`ChangeToken`](crate::ChangeToken) that may change zero or more times.
 #[derive(Default)]
 pub struct DefaultChangeToken {
     once: bool,
-    changed: AtomicBool,
-    callbacks: RwLock<Vec<CallbackWithState>>,
+    notification: Mutex<Notification>,
 }
 
 impl DefaultChangeToken {
@@ -33,31 +84,11 @@ impl DefaultChangeToken {
 
     /// Notifies any registered callbacks of a change.
     pub fn notify(&self) {
-        let result = self
-            .changed
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst);
+        let notification = self.notification.lock().unwrap().fire(self.once);
 
-        if let Ok(notified) = result {
-            if !notified {
-                // acquire a read-lock and capture any callbacks that are still alive.
-                // do NOT invoke the callback with the read-lock held. the callback might
-                // register a new callback on the same token which will result in a deadlock.
-                // invoking the callbacks after the read-lock is released ensures that won't happen.
-                let callbacks: Vec<_> = self
-                    .callbacks
-                    .read()
-                    .unwrap()
-                    .iter()
-                    .filter_map(|r| r.0.upgrade().map(|c| (c, r.1.clone())))
-                    .collect();
-
-                for (callback, state) in callbacks {
-                    callback(state);
-                }
-
-                self.changed
-                    .compare_exchange(true, self.once, Ordering::SeqCst, Ordering::SeqCst)
-                    .ok();
+        if !notification.fired {
+            for (callback, state) in notification {
+                callback(state);
             }
         }
     }
@@ -69,26 +100,11 @@ impl ChangeToken for DefaultChangeToken {
         // will be true, invoke callbacks, and then likely revert to false
         // before it can be observed. it 'might' be useful in an async context,
         // but a callback is the most practical way a change would be observed
-        self.changed.load(Ordering::SeqCst)
+        self.notification.lock().unwrap().fired
     }
 
     fn register(&self, callback: Callback, state: Option<Arc<dyn Any>>) -> Registration {
-        let mut callbacks = self.callbacks.write().unwrap();
-
-        // writes are much infrequent and we already need to escalate
-        // to a write-lock, so do the trimming of any dead callbacks now
-        if !callbacks.is_empty() {
-            for i in (0..callbacks.len()).rev() {
-                if callbacks[i].0.upgrade().is_none() {
-                    callbacks.remove(i);
-                }
-            }
-        }
-
-        let source: Arc<StatefulCallback> = Arc::from(callback);
-
-        callbacks.push((Arc::downgrade(&source), state));
-        Registration::new(source)
+        Registration::new(self.notification.lock().unwrap().register(callback, state))
     }
 }
 
@@ -100,7 +116,7 @@ mod tests {
 
     use super::*;
     use std::sync::{
-        atomic::{AtomicU8, Ordering},
+        atomic::{AtomicU8, Ordering::Relaxed},
         Arc,
     };
 
@@ -127,7 +143,7 @@ mod tests {
                     .unwrap()
                     .downcast_ref::<AtomicU8>()
                     .unwrap()
-                    .fetch_add(1, Ordering::SeqCst);
+                    .fetch_add(1, Relaxed);
             }),
             Some(counter.clone()),
         );
@@ -136,7 +152,7 @@ mod tests {
         token.notify();
 
         // assert
-        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.load(Relaxed), 1);
     }
 
     #[test]
@@ -150,7 +166,7 @@ mod tests {
                     .unwrap()
                     .downcast_ref::<AtomicU8>()
                     .unwrap()
-                    .fetch_add(1, Ordering::SeqCst);
+                    .fetch_add(1, Relaxed);
             }),
             Some(counter.clone()),
         );
@@ -160,6 +176,6 @@ mod tests {
         token.notify();
 
         // assert
-        assert_eq!(counter.load(Ordering::SeqCst), 2);
+        assert_eq!(counter.load(Relaxed), 2);
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,16 +1,15 @@
 use crate::{Callback, ChangeToken, Registration, SingleChangeToken};
-use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
-use std::any::Any;
-use std::mem::ManuallyDrop;
+use notify::{Config, RecommendedWatcher, RecursiveMode::NonRecursive, Watcher};
 use std::path::Path;
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
+use std::{any::Any, mem::ManuallyDrop};
 
 /// Represents a [`ChangeToken`](crate::ChangeToken) for a file.
-/// 
+///
 /// # Remarks
-/// 
+///
 /// Registered notifications always occur on another thread.
 pub struct FileChangeToken {
     watcher: ManuallyDrop<RecommendedWatcher>,
@@ -26,22 +25,32 @@ impl FileChangeToken {
     /// * `path` - The [path](std::path::Path) of the file to watch for changes
     pub fn new<T: AsRef<Path>>(path: T) -> Self {
         let file = path.as_ref().to_path_buf();
+        let path = file.clone();
         let inner = Arc::new(SingleChangeToken::default());
         let handler = inner.clone();
         let (sender, receiver) = channel();
         let mut watcher = RecommendedWatcher::new(sender, Config::default()).unwrap();
-
         let handle = thread::spawn(move || {
             if let Ok(Ok(event)) = receiver.recv() {
-                if event.kind.is_modify() {
-                    handler.notify()
+                let changed =
+                    event.kind.is_modify() || event.kind.is_create() || event.kind.is_remove();
+
+                if changed || event.need_rescan() {
+                    let mut paths = event.paths.iter();
+                    let other = path.as_os_str();
+
+                    if paths.any(|p| p.as_os_str().eq_ignore_ascii_case(other)) {
+                        handler.notify();
+                    }
                 }
             }
         });
 
-        watcher
-            .watch(file.as_ref(), RecursiveMode::NonRecursive)
-            .unwrap();
+        if let Some(folder) = file.parent() {
+            if folder.exists() {
+                watcher.watch(folder, NonRecursive).unwrap();
+            }
+        }
 
         Self {
             watcher: ManuallyDrop::new(watcher),
@@ -79,45 +88,40 @@ impl Drop for FileChangeToken {
 mod tests {
 
     use super::*;
-    use std::env::temp_dir;
-    use std::fs::{remove_file, File};
-    use std::io::Write;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Arc, Condvar, Mutex};
-    use std::time::Duration;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering::Relaxed},
+        Arc, Condvar, Mutex,
+    };
+    use std::time::{Duration, Instant};
+    use std::{fs::File, io::Write};
+    use tempfile::{NamedTempFile, TempPath};
 
     #[test]
     fn changed_should_be_false_when_source_file_is_unchanged() {
         // arrange
-        let path = temp_dir().join("test.1.txt");
-        let mut file = File::create(&path).unwrap();
+        let mut file = NamedTempFile::new().expect("new file");
 
         file.write_all("test".as_bytes()).unwrap();
 
-        let token = FileChangeToken::new(&path);
+        let token = FileChangeToken::new(file.path());
 
         // act
         let changed = token.changed();
 
         // assert
-        if path.exists() {
-            remove_file(&path).ok();
-        }
-
         assert!(!changed);
     }
 
     #[test]
     fn changed_should_be_true_when_source_file_changes() {
         // arrange
-        let path = temp_dir().join("test.2.txt");
-        let mut file = File::create(&path).unwrap();
+        let mut file = NamedTempFile::new().expect("new file");
 
         file.write_all("original".as_bytes()).unwrap();
-        drop(file);
 
+        let path = file.into_temp_path();
         let token = FileChangeToken::new(&path);
-        let mut file = File::create(&path).unwrap();
+        let mut file = NamedTempFile::from_parts(File::create(&path).expect("valid path"), path);
 
         file.write_all("updated".as_bytes()).unwrap();
         thread::sleep(Duration::from_millis(250));
@@ -126,22 +130,17 @@ mod tests {
         let changed = token.changed();
 
         // assert
-        if path.exists() {
-            remove_file(&path).ok();
-        }
-
         assert!(changed);
     }
 
     #[test]
     fn callback_should_be_invoked_when_source_file_changes() {
         // arrange
-        let path = temp_dir().join("test.3.txt");
-        let mut file = File::create(&path).unwrap();
+        let mut file = NamedTempFile::new().expect("new file");
 
         file.write_all("original".as_bytes()).unwrap();
-        drop(file);
 
+        let path = file.into_temp_path();
         let state = Arc::new((Mutex::new(false), Condvar::new(), AtomicBool::default()));
         let token = FileChangeToken::new(&path);
         let _unused = token.register(
@@ -150,43 +149,39 @@ mod tests {
                 let (fired, event, value) = data
                     .downcast_ref::<(Mutex<bool>, Condvar, AtomicBool)>()
                     .unwrap();
-                value.store(true, Ordering::SeqCst);
+                value.store(true, Relaxed);
                 *fired.lock().unwrap() = true;
                 event.notify_one();
             }),
             Some(state.clone()),
         );
-        let mut file = File::create(&path).unwrap();
+        let mut file = NamedTempFile::from_parts(File::create(&path).expect("valid path"), path);
 
         // act
         file.write_all("updated".as_bytes()).unwrap();
-        thread::sleep(Duration::from_millis(250));
 
-        let one_second = Duration::from_secs(1);
+        let time = Instant::now();
+        let quarter_second = Duration::from_millis(250);
+        let three_seconds = Duration::from_secs(3);
         let (mutex, event, changed) = &*state;
         let mut fired = mutex.lock().unwrap();
 
-        while !*fired {
-            fired = event.wait_timeout(fired, one_second).unwrap().0;
+        while !*fired && time.elapsed() < three_seconds {
+            fired = event.wait_timeout(fired, quarter_second).unwrap().0;
         }
 
         // assert
-        if path.exists() {
-            remove_file(&path).ok();
-        }
-
-        assert!(changed.load(Ordering::SeqCst));
+        assert!(changed.load(Relaxed));
     }
 
     #[test]
     fn callback_should_not_be_invoked_after_token_is_dropped() {
         // arrange
-        let path = temp_dir().join("test.4.txt");
-        let mut file = File::create(&path).unwrap();
+        let mut file = NamedTempFile::new().expect("new file");
 
         file.write_all("original".as_bytes()).unwrap();
-        drop(file);
 
+        let path = file.into_temp_path();
         let changed = Arc::<AtomicBool>::default();
         let token = FileChangeToken::new(&path);
         let registration = token.register(
@@ -195,11 +190,11 @@ mod tests {
                     .unwrap()
                     .downcast_ref::<AtomicBool>()
                     .unwrap()
-                    .store(true, Ordering::SeqCst)
+                    .store(true, Relaxed)
             }),
             Some(changed.clone()),
         );
-        let mut file = File::create(&path).unwrap();
+        let mut file = NamedTempFile::from_parts(File::create(&path).expect("valid path"), path);
 
         // act
         drop(registration);
@@ -208,10 +203,85 @@ mod tests {
         thread::sleep(Duration::from_millis(250));
 
         // assert
-        if path.exists() {
-            remove_file(&path).ok();
+        assert_eq!(changed.load(Relaxed), false);
+    }
+
+    #[test]
+    fn callback_should_be_invoked_when_source_file_is_created() {
+        // arrange
+        let path = std::env::temp_dir().join("new_file.txt");
+        let state = Arc::new((Mutex::new(false), Condvar::new(), AtomicBool::default()));
+        let token = FileChangeToken::new(&path);
+        let _unused = token.register(
+            Box::new(|state| {
+                let data = state.unwrap();
+                let (fired, event, value) = data
+                    .downcast_ref::<(Mutex<bool>, Condvar, AtomicBool)>()
+                    .unwrap();
+                value.store(true, Relaxed);
+                *fired.lock().unwrap() = true;
+                event.notify_one();
+            }),
+            Some(state.clone()),
+        );
+        let mut file = NamedTempFile::from_parts(
+            File::create(&path).expect("valid path"),
+            TempPath::from_path(path),
+        );
+
+        // act
+        file.write_all("updated".as_bytes()).unwrap();
+
+        let time = Instant::now();
+        let quarter_second = Duration::from_millis(250);
+        let three_seconds = Duration::from_secs(3);
+        let (mutex, event, changed) = &*state;
+        let mut fired = mutex.lock().unwrap();
+
+        while !*fired && time.elapsed() < three_seconds {
+            fired = event.wait_timeout(fired, quarter_second).unwrap().0;
         }
 
-        assert_eq!(changed.load(Ordering::SeqCst), false);
+        // assert
+        assert!(changed.load(Relaxed));
+    }
+
+    #[test]
+    fn callback_should_be_invoked_when_source_file_is_removed() {
+        // arrange
+        let mut file = NamedTempFile::new().expect("new file");
+
+        file.write_all("existing".as_bytes()).unwrap();
+
+        let state = Arc::new((Mutex::new(false), Condvar::new(), AtomicBool::default()));
+        let token = FileChangeToken::new(file.path());
+        let _unused = token.register(
+            Box::new(|state| {
+                let data = state.unwrap();
+                let (fired, event, value) = data
+                    .downcast_ref::<(Mutex<bool>, Condvar, AtomicBool)>()
+                    .unwrap();
+                value.store(true, Relaxed);
+                *fired.lock().unwrap() = true;
+                event.notify_one();
+            }),
+            Some(state.clone()),
+        );
+
+        // act
+        drop(file);
+
+        let time = Instant::now();
+        let quarter_second = Duration::from_millis(250);
+        let three_seconds = Duration::from_secs(3);
+        let (mutex, event, changed) = &*state;
+        let mut fired = mutex.lock().unwrap();
+
+        while !*fired && time.elapsed() < three_seconds {
+            fired = event.wait_timeout(fired, quarter_second).unwrap().0;
+        }
+
+        // assert
+        assert!(changed.load(Relaxed));
     }
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -11,9 +11,9 @@ use std::{
 /// * `producer` - The function that produces the [change token](crate::ChangeToken)
 /// * `consumer` - The function that is called when the change token changes
 /// * `state` - The optional state supplied to the consumer
-/// 
+///
 /// # Returns
-/// 
+///
 /// An opaque [subscription](crate::Subscription). When it is dropped, the producer
 /// will no longer be polled and the consumer will no longer be notified.
 pub fn on_change<TToken, TProducer, TConsumer, TState>(
@@ -27,7 +27,7 @@ where
     TProducer: Fn() -> TToken + Send + Sync + 'static,
     TConsumer: Fn(Option<Arc<TState>>) + Send + Sync + 'static,
 {
-    SubscriptionImpl(ChangeTokenRegistration::new(producer, consumer, state))
+    ChangeTokenRegistration::new(producer, consumer, state)
 }
 
 struct ChangeTokenRegistration<TToken, TProducer, TConsumer, TState>
@@ -99,17 +99,8 @@ where
     }
 }
 
-struct SubscriptionImpl<TToken, TProducer, TConsumer, TState>(
-    Arc<ChangeTokenRegistration<TToken, TProducer, TConsumer, TState>>,
-)
-where
-    TState: 'static,
-    TToken: ChangeToken + 'static,
-    TProducer: Fn() -> TToken + Send + Sync + 'static,
-    TConsumer: Fn(Option<Arc<TState>>) + Send + Sync + 'static;
-
 impl<TToken, TProducer, TConsumer, TState> Subscription
-    for SubscriptionImpl<TToken, TProducer, TConsumer, TState>
+    for Arc<ChangeTokenRegistration<TToken, TProducer, TConsumer, TState>>
 where
     TState: 'static,
     TToken: ChangeToken + 'static,

--- a/src/global.rs
+++ b/src/global.rs
@@ -137,7 +137,7 @@ mod tests {
     use std::{
         mem::ManuallyDrop,
         sync::{
-            atomic::{AtomicBool, Ordering},
+            atomic::{AtomicBool, Ordering::Relaxed},
             Arc,
         },
     };
@@ -150,7 +150,7 @@ mod tests {
         let producer = token.clone();
         let _unused = on_change(
             move || producer.clone(),
-            |state| state.unwrap().store(true, Ordering::SeqCst),
+            |state| state.unwrap().store(true, Relaxed),
             Some(fired.clone()),
         );
 
@@ -158,7 +158,7 @@ mod tests {
         token.notify();
 
         // assert
-        assert!(fired.load(Ordering::SeqCst));
+        assert!(fired.load(Relaxed));
     }
 
     #[test]
@@ -169,7 +169,7 @@ mod tests {
         let producer = token.clone();
         let subscription = ManuallyDrop::new(on_change(
             move || producer.clone(),
-            |state| state.unwrap().store(true, Ordering::SeqCst),
+            |state| state.unwrap().store(true, Relaxed),
             Some(fired.clone()),
         ));
 
@@ -178,6 +178,6 @@ mod tests {
         token.notify();
 
         // assert
-        assert!(!fired.load(Ordering::SeqCst));
+        assert!(!fired.load(Relaxed));
     }
 }

--- a/src/never.rs
+++ b/src/never.rs
@@ -8,7 +8,7 @@ pub struct NeverChangeToken;
 impl NeverChangeToken {
     /// Initializes a new change token.
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 }
 

--- a/src/single.rs
+++ b/src/single.rs
@@ -49,7 +49,7 @@ mod tests {
 
     use super::*;
     use std::sync::{
-        atomic::{AtomicU8, Ordering},
+        atomic::{AtomicU8, Ordering::Relaxed},
         Arc,
     };
 
@@ -84,7 +84,7 @@ mod tests {
         let token = SingleChangeToken::default();
         let _registration = token.register(
             Box::new(|state| {
-                state.unwrap().downcast_ref::<AtomicU8>().unwrap().fetch_add(1, Ordering::SeqCst);
+                state.unwrap().downcast_ref::<AtomicU8>().unwrap().fetch_add(1, Relaxed);
             }),
             Some(counter.clone()),
         );
@@ -93,7 +93,7 @@ mod tests {
         token.notify();
 
         // assert
-        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.load(Relaxed), 1);
     }
 
     #[test]
@@ -103,7 +103,7 @@ mod tests {
         let token = SingleChangeToken::default();
         let _registration = token.register(
             Box::new(|state| {
-                state.unwrap().downcast_ref::<AtomicU8>().unwrap().fetch_add(1, Ordering::SeqCst);
+                state.unwrap().downcast_ref::<AtomicU8>().unwrap().fetch_add(1, Relaxed);
             }),
             Some(counter.clone()),
         );
@@ -113,6 +113,6 @@ mod tests {
         token.notify();
 
         // assert
-        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.load(Relaxed), 1);
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -8,6 +8,7 @@ type CallbackRef = Arc<dyn Fn(Option<Arc<dyn Any>>) + Send + Sync>;
 /// # Remarks
 ///
 /// When the registration is dropped, the underlying callback is unregistered.
+#[allow(dead_code)]
 pub struct Registration(CallbackRef);
 
 impl Registration {


### PR DESCRIPTION
This CR makes the following fixes and enhancements to the `FileChangeToken`:

1. Handle changes for a non-existent file
    a. The containing folder must still exist and will not be automatically created
    b. If containing folder does not exist, nothing happens
    c. A change fires if the source file is created or updated
2. If the file is deleted, it signals a change
    a. This may also fire during a file rename
4. File paths are compared with case-insensitivity

Fixes #5